### PR TITLE
Fix : 최초 채팅방 리스트 조회 시 최신화 리스트 조회 로직 반영

### DIFF
--- a/src/main/java/com/catchroom/chat/chatroom/dto/ChatRoomListGetResponse.java
+++ b/src/main/java/com/catchroom/chat/chatroom/dto/ChatRoomListGetResponse.java
@@ -1,5 +1,6 @@
 package com.catchroom.chat.chatroom.dto;
 
+import com.catchroom.chat.chatroom.type.DealState;
 import com.catchroom.chat.message.dto.ChatMessageDto;
 import com.catchroom.chat.message.type.UserIdentity;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,7 @@ public class ChatRoomListGetResponse {
     private String accommodationUrl;
     private String partnerNickName;
     private ChatMessageDto lastChatmessageDto;
+    private DealState dealState;
 
     public void updateChatMessageDto(ChatMessageDto chatMessageDto) {
         this.lastChatmessageDto = chatMessageDto;

--- a/src/main/java/com/catchroom/chat/chatroom/type/DealState.java
+++ b/src/main/java/com/catchroom/chat/chatroom/type/DealState.java
@@ -1,0 +1,5 @@
+package com.catchroom.chat.chatroom.type;
+
+public enum DealState {
+    UNSOLD,ONSALE,EXPIRED,DONEDEAL,UNABLESELL
+}


### PR DESCRIPTION
- 39번 API 채팅방 리스트 최신화 정렬 변경(최근 시간 순)